### PR TITLE
Add exception to geometry test for AirNode

### DIFF
--- a/tn-as/geometry.md
+++ b/tn-as/geometry.md
@@ -10,9 +10,13 @@
 
 Automated assertions:
 
-* If the TransportNode and the TransportLink feature types are contained in the same dataset, using a geometry library, verify for each [TransportNode](#TransportNode) that the [geometry](#geometry) (a gml:Point) is located a position that touches a [TransportLink](#TransportLink).[centerlineGeometry](#centerlineGeometry) (a gml:LineString or gml:Curve), i.e. that the node is at the start or end of a transport link. If the check fails report [freeNode](#freeNode).
+* If the TransportNode and the TransportLink feature types are contained in the same dataset, using a geometry library, verify for each [TransportNode](#TransportNode) that the [geometry](#geometry) (a gml:Point) is located a position that touches a [TransportLink](#TransportLink).[centerlineGeometry](#centerlineGeometry) (a gml:LineString or gml:Curve), i.e. that the node is at the start or end of a transport link. If the check fails report the [freeNode](#freeNode) error message.
 
   *  Otherwise, if the TransportNode and the TransportLink feature types are not contained in the same dataset, a manual check is required to verify that for each [TransportNode](#TransportNode) the [geometry](#geometry) (a gml:Point) is located a position that touches a [TransportLink](#TransportLink).[centerlineGeometry](#centerlineGeometry) (a gml:LineString or gml:Curve), in this case report the message [freeNodeManualCheck](#freeNodeManualCheck).
+
+Exception: 
+
+* The nodes related to the AirNode feature type (i.e. nodes related to the Navaid, DesignatedPoint, RunwayCentrelinePoint, AerodromeNode and TouchDownLiftOff feature types) are excluded by this check if the value of the [significantPoint](#signPoint) attribute is equal to "false", since an AirNode is not necessarily placed at the end or start of a Transport Link when it is not used for navigation/ATS purposes.
 
 Manual assertions:
 
@@ -42,3 +46,4 @@ TransportNode <a name="TransportNode"></a> 	| 	//schema-element(tn-ro:RoadNode) 
 geometry <a name="geometry"></a>   | $TransportNode/*/gml:Point
 TransportLink <a name="TransportLink"></a> 	| 	//schema-element(tn-ro:RoadLink) or //schema-element(tn-ra:RailwayLink) or //schema-element(tn-c:CablewayLink) or //schema-element(tn-w:WaterwayLink) or //schema-element(tn-a:AirRouteLink) or //schema-element(tn-a: ProcedureLink) or //schema-element(tn-a:StandardInstrumentDeparture) or //schema-element(tn-a:InstrumentApproachProcedure) or //schema-element(tn-a:StandardInstrumentArrival)
 TransportLink.centerlineGeometry <a name="centerlineGeometry"></a>   | $TransportLink/tn:centerlineGeometry 
+significantPoint <a name="signPoint"></a> 	| //schema-element(tn-a:Navaid)/tn-a:significantPoint <br> //schema-element(tn-a:DesignatedPoint)/tn-a:significantPoint <br> //schema-element(tn-a:RunwayCentrelinePoint)/tn-a:significantPoint <br> //schema-element(tn-a:TouchDownLiftOff)/tn-a:significantPoint <br> //schema-element(tn-a:AerodromeNode)/tn-a:significantPoint


### PR DESCRIPTION
An exception was added for the AirNode according to https://github.com/INSPIRE-MIF/helpdesk-validator/issues/113 issue.